### PR TITLE
Update initiatives page to link Snail Language Support repository

### DIFF
--- a/_pages/initiatives.md
+++ b/_pages/initiatives.md
@@ -10,5 +10,6 @@ Snail is still under active development by [Kevin
 Angstadt](https://github.com/kevinaangstadt), Professor of Computer
 Science at St. Lawrence University, and his loyal companions. Below is a list of some active and past initiatives for reference.
 
-* Visual Studio Code Support (Project under active development)
-   - Adding various support for Snail inside Visual Studio Code, i.e. syntax highlighting, auto-complete, and a fully-fledged debugger.
+* [Snail Language Support](https://github.com/snail-language/snail-language-support) (active development)
+   - Visual Studio Code Extension to add language support for snail (syntax highlighting, snippet autocomplete, error diagnostics)
+   - Future work includes implementing a debugger for snail using the Debug Adapter Protocol


### PR DESCRIPTION
Modify the initiatives page to include updated documentation on the state of Snail Language Support VS Code extension.

Tested locally on Charlie's machine by building and serving the webpage on `localhost:4000`